### PR TITLE
Fix webpack setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist/bundle.js

--- a/dist/index.html
+++ b/dist/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Test1</title>
-  <base href="/">
+
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
@@ -13,5 +13,5 @@
 
   <app-root></app-root>
   <script src="bundle.js"></script>
-<script type="text/javascript" src="inline.bundle.js"></script><script type="text/javascript" src="polyfills.bundle.js"></script><script type="text/javascript" src="styles.bundle.js"></script><script type="text/javascript" src="vendor.bundle.js"></script><script type="text/javascript" src="main.bundle.js"></script></body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
+    "angular2-template-loader": "^0.6.2",
     "codelyzer": "^4.0.1",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
@@ -40,9 +41,10 @@
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~5.1.2",
+    "raw-loader": "^0.5.1",
+    "ts-loader": "3.2.0",
     "ts-node": "~3.2.0",
     "tslint": "~5.7.0",
-    "typescript": "~2.4.2",
-    "ts-loader": "3.2.0"
+    "typescript": "~2.4.2"
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  templateUrl: './app.component.html'
 })
 export class AppComponent {
   title = 'app';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import 'zone.js';
+
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,9 @@ module.exports = {
   module: {
     rules: [
       // all files with a `.ts` extension will be handled by `ts-loader`
-      { test: /\.ts$/, loader: 'ts-loader' }
+      { test: /\.ts$/, loader: 'ts-loader' },
+      { test: /\.ts$/, loader: 'angular2-template-loader' },
+      { test: /\.(html|css)$/, loader: 'raw-loader' }
     ]
   },
   plugins: [


### PR DESCRIPTION
This PR fixes two problems;

 * The `baseUrl` setting in `index.html` required you to run the webserver inside `dist`, or `bundle.js` wouldn't be found
 * Webpack wasn't set up to handle inlining of external templates

Now the bundle works! :)